### PR TITLE
feat: support hessian 4

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,31 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm i -g npminstall && npminstall
+    - run: npm run ci
+      env:
+        CI: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
-sudo: false
+
 language: node_js
 node_js:
-  - '8'
   - '10'
+  - '12'
+  - '14'
 before_install:
   - npm i npminstall -g
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,8 @@
 environment:
   matrix:
-    - nodejs_version: '8'
     - nodejs_version: '10'
+    - nodejs_version: '12'
+    - nodejs_version: '14'
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/lib/codec/hessian/app_type/rpc_server_exception.js
+++ b/lib/codec/hessian/app_type/rpc_server_exception.js
@@ -1,16 +1,9 @@
 'use strict';
 
-const compile = require('sofa-hessian-node').compile;
+const { compile } = require('../hessian');
 const builtInClassMap = require('./builtin_class_map');
 
-const encodeRpcServerExceptionMap = {
-  hessian2: compile({
-    type: 'com.alipay.remoting.rpc.exception.RpcServerException',
-  }, '2.0', builtInClassMap),
-};
-
 exports.encode = (target, encoder) => {
-  const codecType = target.codecType;
   const err = target.obj;
 
   const detailMessage = err.name + ': ' + err.message;
@@ -52,7 +45,9 @@ exports.encode = (target, encoder) => {
     }
   }
 
-  encodeRpcServerExceptionMap[codecType]({
+  compile({
+    type: 'com.alipay.remoting.rpc.exception.RpcServerException',
+  }, '2.0', builtInClassMap)({
     detailMessage,
     stackTrace,
     cause: null,

--- a/lib/codec/hessian/app_type/sofa_request.js
+++ b/lib/codec/hessian/app_type/sofa_request.js
@@ -1,14 +1,8 @@
 'use strict';
 
 const utils = require('../../../utils');
-const compile = require('sofa-hessian-node').compile;
+const { compile } = require('../hessian');
 const builtInClassMap = require('./builtin_class_map');
-
-const encodeSofaRequestMap = {
-  hessian2: compile({
-    type: 'com.alipay.sofa.rpc.core.request.SofaRequest',
-  }, '2.0', builtInClassMap),
-};
 
 exports.encode = (target, encoder) => {
   const req = target.obj;
@@ -22,7 +16,9 @@ exports.encode = (target, encoder) => {
     methodArgSigs.push(utils.getJavaClassname(methodArgs[i]));
   }
   // encode SofaRequest
-  encodeSofaRequestMap[codecType]({
+  compile({
+    type: 'com.alipay.sofa.rpc.core.request.SofaRequest',
+  }, '2.0', builtInClassMap)({
     targetAppName: req.targetAppName,
     methodName: req.methodName,
     methodArgSigs,

--- a/lib/codec/hessian/app_type/sofa_response.js
+++ b/lib/codec/hessian/app_type/sofa_response.js
@@ -1,17 +1,12 @@
 'use strict';
 
-const compile = require('sofa-hessian-node').compile;
+const { compile } = require('../hessian');
 const builtInClassMap = require('./builtin_class_map');
 
-const encodeSofaResponseMap = {
-  hessian2: compile({
-    type: 'com.alipay.sofa.rpc.core.response.SofaResponse',
-  }, '2.0', builtInClassMap),
-};
-
 exports.encode = (target, encoder) => {
-  const codecType = target.codecType;
-  encodeSofaResponseMap[codecType](target.obj, encoder, target.classMap);
+  compile({
+    type: 'com.alipay.sofa.rpc.core.response.SofaResponse',
+  }, '2.0', builtInClassMap)(target.obj, encoder, target.classMap);
 };
 
 exports.decode = decoder => {

--- a/lib/codec/hessian/hessian.js
+++ b/lib/codec/hessian/hessian.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const { v3, v4 } = require('sofa-hessian-node');
+
+const encoder_v3 = new v3.Encoder({ size: 1 });
+const decoder_v3 = new v3.Decoder();
+const encoder_v4 = new v4.Encoder({ size: 1 });
+const decoder_v4 = new v4.Decoder();
+
+// 默认为 hessian 3.0
+let version = '3.0';
+
+exports.getEncoder = () => {
+  return version === '3.0' ? encoder_v3 : encoder_v4;
+};
+
+exports.getDecoder = () => {
+  return version === '3.0' ? decoder_v3 : decoder_v4;
+};
+
+
+exports.compile = (...args) => {
+  if (version === '3.0') {
+    return v3.compile(...args);
+  }
+  return v4.compile(...args);
+};
+
+exports.setVersion = ver => {
+  version = ver;
+};

--- a/lib/codec/hessian/index.js
+++ b/lib/codec/hessian/index.js
@@ -1,12 +1,7 @@
 'use strict';
 
-const EncoderV2 = require('hessian.js-1').EncoderV2;
-const DecoderV2 = require('hessian.js-1').DecoderV2;
 const appTypeMap = require('./app_type/app_type_map');
-const encoder = new EncoderV2({ size: 1 });
-const decoder = new DecoderV2();
-
-const originByteBuffer = encoder.byteBuffer;
+const { compile, getEncoder, getDecoder, setVersion } = require('./hessian');
 
 /**
  * 编码
@@ -15,13 +10,16 @@ const originByteBuffer = encoder.byteBuffer;
  * @return {void}
  */
 exports.encode = (byteBuffer, cmd) => {
+  const encoder = getEncoder();
   const className = cmd.className;
+  const originByteBuffer = encoder.byteBuffer;
 
   encoder.byteBuffer = originByteBuffer;
   encoder.reset();
   encoder.byteBuffer = byteBuffer;
 
   appTypeMap[className].encode(cmd, encoder);
+  encoder.byteBuffer = originByteBuffer;
 };
 
 /**
@@ -33,6 +31,7 @@ exports.encode = (byteBuffer, cmd) => {
  * @return {Object} 反序列化结果
  */
 exports.decode = (byteBuffer, className, options) => {
+  const decoder = getDecoder();
   className = className.trim();
   decoder.byteBuffer = byteBuffer;
   decoder.refMap = {};
@@ -47,3 +46,6 @@ exports.decode = (byteBuffer, className, options) => {
   }
   return decoder.read();
 };
+
+exports.setVersion = setVersion;
+exports.compile = compile;

--- a/lib/codec/index.js
+++ b/lib/codec/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
 module.exports = {
-  hessian2: require('./hessian/v2'),
+  hessian2: require('./hessian'),
   protobuf: require('./protobuf'),
 };

--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -80,9 +80,9 @@ class ProtocolDecoder extends Writable {
     return false;
   }
 
-  _destroy() {
+  _destroy(err, callback) {
     this._buf = null;
-    this.emit('close');
+    callback(err);
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,7 @@
 const assert = require('assert');
 const ProtocolEncoder = require('./encoder');
 const ProtocolDecoder = require('./decoder');
-const compile = require('sofa-hessian-node').compile;
+const { compile, setVersion } = require('./codec/hessian');
 const builtinClazzMap = require('./codec/hessian/app_type/builtin_class_map');
 const appTypeMap = require('./codec/hessian/app_type/app_type_map');
 exports.BaseRpcCmd = require('./protocol/rpc_cmd');
@@ -11,7 +11,10 @@ exports.codec = require('./codec');
 
 const globalOptions = {};
 
-exports.setOptions = options => {
+exports.setOptions = (options = {}) => {
+  if (options.hessianVersion) {
+    setVersion(options.hessianVersion);
+  }
   Object.assign(globalOptions, options);
 };
 
@@ -28,20 +31,17 @@ exports.registerAppClazzMap = function(clazzMap) {
   const clazzs = Object.keys(clazzMap);
   Object.assign(builtinClazzMap, clazzMap);
   for (const clazz of clazzs) {
-    const encodeMap = {
-      hessian: compile({ type: clazz }, '1.0', builtinClazzMap),
-      hessian2: compile({ type: clazz }, '2.0', builtinClazzMap),
-    };
-
     appTypeMap[clazz] = {
-      encode: (target, encoder) => {
-        encodeMap[ target.codecType ](target.obj, encoder);
+      encode(target, encoder) {
+        compile({ type: clazz }, '2.0', builtinClazzMap)(target.obj, encoder);
       },
-      decode: decoder => {
+      decode(decoder) {
         return decoder.readObject();
       },
     };
   }
 };
+
+exports.setHessianVersion = setVersion;
 
 exports.RpcClient = require('./rpc_client');

--- a/package.json
+++ b/package.json
@@ -33,34 +33,33 @@
   "homepage": "https://github.com/alipay/sofa-bolt-node#readme",
   "dependencies": {
     "byte": "^2.0.0",
-    "connection": "^1.0.0",
+    "connection": "^1.1.0",
     "crc": "^3.8.0",
-    "hessian.js-1": "^1.8.3",
-    "is-type-of": "^1.2.0",
+    "is-type-of": "^1.2.1",
     "sdk-base": "^3.6.0",
-    "sofa-hessian-node": "^1.0.1",
-    "utility": "^1.14.0"
+    "sofa-hessian-node": "^2.0.0",
+    "utility": "^1.16.3"
   },
   "devDependencies": {
     "antpb": "^1.0.0",
-    "autod": "^3.0.1",
+    "autod": "^3.1.0",
     "await-event": "^2.1.0",
     "benchmark": "^2.1.4",
     "contributors": "^0.5.1",
-    "egg-bin": "^4.7.1",
-    "egg-ci": "^1.8.0",
-    "eslint": "^5.2.0",
-    "eslint-config-egg": "^7.0.0",
+    "egg-bin": "^4.14.1",
+    "egg-ci": "^1.15.0",
+    "eslint": "^7.2.0",
+    "eslint-config-egg": "^8.0.1",
     "js-to-java": "^2.5.0",
     "long": "^4.0.0",
-    "mm": "^2.2.2",
+    "mm": "^3.2.0",
     "mz-modules": "^2.1.0",
     "pump": "^3.0.0"
   },
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 10.0.0"
   },
   "ci": {
-    "version": "8, 10"
+    "version": "10, 12, 14"
   }
 }

--- a/test/exception.test.js
+++ b/test/exception.test.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 const ByteBuffer = require('byte');
-const hessianV2 = require('../lib/codec/hessian/v2');
+const hessianV2 = require('../lib/codec/hessian');
 
 describe('test/exception.test.js', () => {
   it('should decode java Exception ok', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -34,151 +34,166 @@ describe('test/index.test.js', () => {
   };
 
   [
-    [ 'bolt2', 'hessian2', 2, true ],
-    [ 'bolt2', 'hessian2', 2, false ],
-    [ 'bolt2', 'hessian2', 1, false ],
-    [ 'bolt', 'hessian2', null, null ],
-  ].forEach(data => {
-    const [ protocolType, codecType, boltVersion, crcEnable ] = data;
-    let extra = '';
-    if (protocolType === 'bolt2') {
-      extra = '+ boltVersion: ' + boltVersion + ' + crcEnable: ' + crcEnable;
-    }
-    describe(protocolType + ' + ' + codecType + extra, () => {
-      it('should encode/decode request / response', async function() {
-        const options = {
-          sentReqs: new Map(),
-          classMap,
-        };
-        const socket = new PassThrough();
-        const encoder = protocol.encoder(options);
-        const decoder = protocol.decoder(options);
-        encoder.pipe(socket).pipe(decoder);
-        encoder.protocolType = protocolType;
-        encoder.codecType = codecType;
-        encoder.boltVersion = boltVersion;
-        encoder.crcEnable = crcEnable;
-
-        let item = await Promise.all([
-          awaitEvent(decoder, 'request'),
-          new Promise((resolve, reject) => {
-            encoder.writeRequest(1, {
-              args: [{
-                $class: 'com.alipay.test.TestObj',
-                $: obj,
-              }],
-              serverSignature: 'com.alipay.test.TestService:1.0',
-              methodName: 'echoObj',
-              requestProps: {},
-              timeout: 3000,
-            }, (err, packet) => { err ? reject(err) : resolve(packet); });
-          }),
-        ]);
-        const req = item[0];
-        let input = item[1];
-
-        assert(req.packetId === input.packetId);
-        assert(req.packetType === input.packetType);
-        assert(req.data && !req.data.targetAppName);
-        assert(req.data.methodName === 'echoObj');
-        assert(req.data.serverSignature === 'com.alipay.test.TestService:1.0');
-
-        assert(input.meta && Buffer.isBuffer(input.meta.data));
-        assert(input.meta.protocolType === protocolType);
-        assert(input.meta.codecType === codecType);
-
-        const [ size1, size2 ] = await Promise.all([
-          null,
-          classMap,
-        ].map(async classMap => {
-          item = await Promise.all([
-            awaitEvent(decoder, 'response'),
-            new Promise((resolve, reject) => {
-              encoder.writeResponse(req, {
-                isError: false,
-                appResponse: {
-                  $class: 'com.alipay.test.TestObj',
-                  $: obj,
-                },
-                classMap,
-              }, (err, packet) => { err ? reject(err) : resolve(packet); });
-            }),
-          ]);
-
-          const res = item[0];
-          input = item[1];
-
-          assert(res.packetId === req.packetId);
-          assert(res.packetType === 'response');
-          assert(res.data);
-          assert(!res.data.error);
-          assert.deepEqual(res.data.appResponse, obj);
-
-          assert(input.meta && Buffer.isBuffer(input.meta.data));
-          assert(input.meta.protocolType === protocolType);
-          assert(input.meta.codecType === codecType);
-
-          return input.meta.size;
-        }));
-
-        assert(size1 === size2);
+    '3.0',
+    '4.0',
+  ].forEach(version => {
+    describe(version, () => {
+      before(() => {
+        protocol.setHessianVersion(version);
       });
-    });
-  });
 
-  describe('registerAppClazzMap', () => {
-    it('should success', async () => {
-      registerAppClazzMap({
-        'com.alipay.foo': {
-          hello: {
-            type: 'java.lang.String',
-          },
-        },
+      after(() => {
+        protocol.setOptions({ hessianVersion: '3.0' });
       });
-      const options = {
-        sentReqs: new Map(),
-        classMap,
-        address: urlparse('tr://foo.net:12200?_SERIALIZETYPE=hessian2', true),
-      };
 
-      const encoder = protocol.encoder(options);
-      const decoder = protocol.decoder(options);
-      const socket = new PassThrough();
-      encoder.pipe(socket).pipe(decoder);
-      encoder.protocolType = 'bolt2';
-      encoder.codecType = 'hessian2';
-      encoder.boltVersion = 2;
-      encoder.sofaVersion = '4.0';
-      encoder.crcEnable = true;
-
-      class FooClass extends BaseRpcCmd {
-        serializeHeader() {}
-
-        serializeContent(byteBuffer) {
-          const codec = codecMap[this.codecType];
-          codec.encode(byteBuffer, this);
+      [
+        [ 'bolt2', 'hessian2', 2, true ],
+        [ 'bolt2', 'hessian2', 2, false ],
+        [ 'bolt2', 'hessian2', 1, false ],
+        [ 'bolt', 'hessian2', null, null ],
+      ].forEach(data => {
+        const [ protocolType, codecType, boltVersion, crcEnable ] = data;
+        let extra = '';
+        if (protocolType === 'bolt2') {
+          extra = '+ boltVersion: ' + boltVersion + ' + crcEnable: ' + crcEnable;
         }
+        describe(protocolType + ' + ' + codecType + extra, () => {
+          it('should encode/decode request / response', async function() {
+            const options = {
+              sentReqs: new Map(),
+              classMap,
+            };
+            const socket = new PassThrough();
+            const encoder = protocol.encoder(options);
+            const decoder = protocol.decoder(options);
+            encoder.pipe(socket).pipe(decoder);
+            encoder.protocolType = protocolType;
+            encoder.codecType = codecType;
+            encoder.boltVersion = boltVersion;
+            encoder.crcEnable = crcEnable;
 
-        get className() {
-          return 'com.alipay.foo';
-        }
+            let item = await Promise.all([
+              awaitEvent(decoder, 'request'),
+              new Promise((resolve, reject) => {
+                encoder.writeRequest(1, {
+                  args: [{
+                    $class: 'com.alipay.test.TestObj',
+                    $: obj,
+                  }],
+                  serverSignature: 'com.alipay.test.TestService:1.0',
+                  methodName: 'echoObj',
+                  requestProps: {},
+                  timeout: 3000,
+                }, (err, packet) => { err ? reject(err) : resolve(packet); });
+              }),
+            ]);
+            const req = item[0];
+            let input = item[1];
 
-        get timeout() {
-          return this.obj.timeout || 3000;
-        }
-      }
+            assert(req.packetId === input.packetId);
+            assert(req.packetType === input.packetType);
+            assert(req.data && !req.data.targetAppName);
+            assert(req.data.methodName === 'echoObj');
+            assert(req.data.serverSignature === 'com.alipay.test.TestService:1.0');
 
-      const obj = new FooClass({
-        hello: 'world',
+            assert(input.meta && Buffer.isBuffer(input.meta.data));
+            assert(input.meta.protocolType === protocolType);
+            assert(input.meta.codecType === codecType);
+
+            const [ size1, size2 ] = await Promise.all([
+              null,
+              classMap,
+            ].map(async classMap => {
+              item = await Promise.all([
+                awaitEvent(decoder, 'response'),
+                new Promise((resolve, reject) => {
+                  encoder.writeResponse(req, {
+                    isError: false,
+                    appResponse: {
+                      $class: 'com.alipay.test.TestObj',
+                      $: obj,
+                    },
+                    classMap,
+                  }, (err, packet) => { err ? reject(err) : resolve(packet); });
+                }),
+              ]);
+
+              const res = item[0];
+              input = item[1];
+
+              assert(res.packetId === req.packetId);
+              assert(res.packetType === 'response');
+              assert(res.data);
+              assert(!res.data.error);
+              assert.deepEqual(res.data.appResponse, obj);
+
+              assert(input.meta && Buffer.isBuffer(input.meta.data));
+              assert(input.meta.protocolType === protocolType);
+              assert(input.meta.codecType === codecType);
+
+              return input.meta.size;
+            }));
+
+            assert(size1 === size2);
+          });
+        });
       });
 
-      const p = awaitEvent(decoder, 'request');
-      encoder.writeRequest(1, obj, err => {
-        assert(!err);
+      describe('registerAppClazzMap', () => {
+        it('should success', async () => {
+          registerAppClazzMap({
+            'com.alipay.foo': {
+              hello: {
+                type: 'java.lang.String',
+              },
+            },
+          });
+          const options = {
+            sentReqs: new Map(),
+            classMap,
+            address: urlparse('tr://foo.net:12200?_SERIALIZETYPE=hessian2', true),
+          };
+
+          const encoder = protocol.encoder(options);
+          const decoder = protocol.decoder(options);
+          const socket = new PassThrough();
+          encoder.pipe(socket).pipe(decoder);
+          encoder.protocolType = 'bolt2';
+          encoder.codecType = 'hessian2';
+          encoder.boltVersion = 2;
+          encoder.sofaVersion = '4.0';
+          encoder.crcEnable = true;
+
+          class FooClass extends BaseRpcCmd {
+            serializeHeader() {}
+
+            serializeContent(byteBuffer) {
+              const codec = codecMap[this.codecType];
+              codec.encode(byteBuffer, this);
+            }
+
+            get className() {
+              return 'com.alipay.foo';
+            }
+
+            get timeout() {
+              return this.obj.timeout || 3000;
+            }
+          }
+
+          const obj = new FooClass({
+            hello: 'world',
+          });
+
+          const p = awaitEvent(decoder, 'request');
+          encoder.writeRequest(1, obj, err => {
+            assert(!err);
+          });
+          const req = await p;
+          assert(req.className, 'com.alipay.foo');
+          assert.deepStrictEqual(req.data, { hello: 'world' });
+        });
       });
-      const req = await p;
-      assert(req.className, 'com.alipay.foo');
-      assert.deepStrictEqual(req.data, { hello: 'world' });
     });
   });
 });


### PR DESCRIPTION
ref: https://github.com/sofastack/sofa-rpc-node/issues/57

Java 的实现里 hessian 3 和 4 是互斥的，所以我们也用一个开关来设置

```js
const bolt = require('sofa-bolt-node');

bolt.setHessianVersion('4.0');

// 或者 bolt.setOptions({ hessianVersion: '4.0' });
```